### PR TITLE
erlang 26.1 with rust 1.74.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
-_rel
-repos
+/_rel
+/deps
+/ebin
+/repos
+/shrugs.d

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         erlang:
-          - "26.0.2"
+          - "26.1.2"
         rust:
-          - "1.70.0"
+          - "1.74.0"
     runs-on: ubuntu-latest
     outputs:
       image: ${{steps.bdra.outputs.image}}

--- a/bin/build
+++ b/bin/build
@@ -33,10 +33,11 @@ fi
 
 
 docker build \
+       --no-cache \
        --file "$bdra/Dockerfile" \
        --progress plain \
-       --tag shrugs:latest \
-       --build-arg BUILD_IMAGE=ghcr.io/shortishly/erlang-rust:26.0.2-1.70.0 \
+       --tag "ghcr.io/$(gh repo view --json nameWithOwner --jq .nameWithOwner)" \
+       --build-arg BUILD_IMAGE=ghcr.io/shortishly/erlang-rust:26.1.2-1.74.0 \
        --build-arg GITHUB_REPOSITORY=$(gh repo view --json nameWithOwner --jq .nameWithOwner) \
        --build-arg BUILD_COMMAND=make \
        "$repo_root"


### PR DESCRIPTION
update ci to:

- erlang 26.1.2
- rust 1.74.0

local docker builds will now tag using ghcr.io/shortishly/shrugs (previously just "shrugs") to be simpler to work with the compose file.