### PR TITLE
updated smoke test not including git --global config

### DIFF
--- a/test/bats/.gitignore
+++ b/test/bats/.gitignore
@@ -1,0 +1,2 @@
+bob
+bob.pub

--- a/test/bats/smoke.bats
+++ b/test/bats/smoke.bats
@@ -33,9 +33,7 @@ setup() {
 }
 
 @test "init_commit_clone" {
-    git config --global init.defaultBranch main
-    git config --global user.email "bob@example.com"
-    git config --global user.name "Bob Example"
+    git config init.defaultBranch main
 
     INIT_DIR=$(mktemp -d)
     git -C "$INIT_DIR" init


### PR DESCRIPTION
- disable global and system git config while running tests
-  remove usage of "git --global config" using local configuration instead (init, commit/etc)
- use "-i" parameter to ssh and IdentitiesOnly=true option
- use same GIT_SSH_COMMAND on both tests